### PR TITLE
Adding the missing namespace specification for "endl" in the second example of page 16, chapter 2.

### DIFF
--- a/doc/src/book/chapter2.tex
+++ b/doc/src/book/chapter2.tex
@@ -248,7 +248,7 @@ int main (int argc, char* argv[])
 //  convert the text argv[1] to double using atof: 
   double r = atof(argv[1]); 
   double s = sin(r);
-  std::cout << "Hello, World! sin(" << r << ")=" << s << endl;
+  std::cout << "Hello, World! sin(" << r << ")=" << s << std::endl;
 // success 
   return 0;  
 }

--- a/doc/src/book/chapters/Chapter2/chapter2.tex
+++ b/doc/src/book/chapters/Chapter2/chapter2.tex
@@ -252,7 +252,7 @@ int main (int argc, char* argv[])
 //  convert the text argv[1] to double using atof: 
   double r = atof(argv[1]); 
   double s = sin(r);
-  std::cout << "Hello, World! sin(" << r << ")=" << s << endl;
+  std::cout << "Hello, World! sin(" << r << ")=" << s << std::endl;
 // success 
   return 0;  
 }

--- a/doc/src/book/chapters/Chapter2/chapter2.tex~
+++ b/doc/src/book/chapters/Chapter2/chapter2.tex~
@@ -262,7 +262,7 @@ int main (int argc, char* argv[])
 //  convert the text argv[1] to double using atof: 
   double r = atof(argv[1]); 
   double s = sin(r);
-  std::cout << "Hello, World! sin(" << r << ")=" << s << endl;
+  std::cout << "Hello, World! sin(" << r << ")=" << s << std::endl;
 // success 
   return 0;  
 }


### PR DESCRIPTION
In chapter 2, page 16, the line 10 of the second version of the C++ Hello World was incorrect. The endl function is under the std namespace, just as cout, thus the statement must be:
*std::cout << "Hello, World! sin(" << r << ")=" << s << std::endl;*
instead of:
*std::cout << "Hello, World! sin(" << r << ")=" << s << endl;*